### PR TITLE
Fix little error in Installaion Notes

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -81,7 +81,7 @@ do one of the following:
 
  * copy the file into your bash configuration folder like this:
 
-    $ copy path/to/djntest.sh /etc/bash_completion.d/
+    $ cp path/to/djntest.sh /etc/bash_completion.d/
 
 And later restart your bash session.
 


### PR DESCRIPTION
'copy' isn't a valid Unix/Linux command.
